### PR TITLE
http gemへの依存を削除

### DIFF
--- a/pay_design.gemspec
+++ b/pay_design.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "http", "~> 0.9.8"
-
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
使用していなかった `http` gem への依存を削除しました。

別の gem と合わせて利用するときに、依存する `http` gem のバージョンが食い違ってインストールエラーが発生しました。そこでこのライブラリが依存する `http` gem のバージョンを更新しようとしたのですが、コード上で `http` gem を使っているところが見当たりませんでした。

```bash
$ grep -ri http lib
lib/pay_design/convenience_store/callbacks.rb:      # How actual HTTP-level behaves depends on what the library user is.
lib/pay_design/convenience_store.rb:      LINK_STYLE_URL   = "https://www.paydesign.jp/settle/settle3/bp3.dll"
lib/pay_design/convenience_store.rb:      SERVER_STYLE_URL = "https://www.paydesign.jp/settle/settle2/ubp3.dll"
```

（↑の他にファイルを一通り目視で確認しています。）

そこで `http` gem への依存は削除してしまいました。削除してもテストはすべて通りました:ok_woman: